### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, redirect, url_for, send_from_directory, flash
+from flask import Flask, render_template, request, redirect, url_for, send_from_directory, flash, abort
 import os
 import uuid
 from PIL import Image
@@ -54,8 +54,16 @@ def upload_file():
 
 @app.route('/delete/<filename>', methods=['POST'])
 def delete_file(filename):
-    file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
-    thumb_path = os.path.join(app.config['THUMBNAIL_FOLDER'], filename)
+    # Normalize and validate file_path
+    upload_folder_abs = os.path.abspath(app.config['UPLOAD_FOLDER'])
+    thumbnail_folder_abs = os.path.abspath(app.config['THUMBNAIL_FOLDER'])
+    file_path = os.path.normpath(os.path.join(upload_folder_abs, filename))
+    thumb_path = os.path.normpath(os.path.join(thumbnail_folder_abs, filename))
+
+    # Ensure the paths are within the intended directories
+    if not file_path.startswith(upload_folder_abs) or not thumb_path.startswith(thumbnail_folder_abs):
+        flash('Nombre de archivo no permitido.', 'danger')
+        return redirect(url_for('index'))
 
     if os.path.exists(file_path):
         os.remove(file_path)


### PR DESCRIPTION
Potential fix for [https://github.com/brunojhovany/pedidos-cdn/security/code-scanning/5](https://github.com/brunojhovany/pedidos-cdn/security/code-scanning/5)

To fix this vulnerability, we need to ensure that the `filename` parameter cannot be used to perform path traversal or access files outside the intended directories. The best way to do this is to:

1. Normalize the constructed file paths using `os.path.normpath`.
2. Check that the resulting paths are still within the intended upload and thumbnail directories by verifying that the normalized path starts with the absolute path of the respective directory.
3. Optionally, use `werkzeug.utils.secure_filename` to further sanitize the filename, but since the files are saved with UUIDs, normalization and prefix checking should suffice.

We will update the `delete_file` function to:
- Normalize and check both `file_path` and `thumb_path` before performing any file operations.
- Abort the request or flash an error if the check fails.

We will also need to import `abort` from `flask` if not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
